### PR TITLE
Updating ci.yml to use new output mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           color: warning
       - name: Get yarn cache
         id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}


### PR DESCRIPTION
Github has declared `set-output` to be [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and reccomends instead setting via environment variables.  This PR does this.