### PR TITLE
Updating actions/cache to use new non-set-output method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get yarn cache
         id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3.3.1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Purpose

Looks like `actions/cache` also used `set-output`, and removed the deprecated call in [v3.0.11](https://github.com/actions/cache/blob/main/RELEASES.md#3011).